### PR TITLE
Fix KeyError caused by missing 'Num' key in Picamera2 camera info

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug.yml
+++ b/.github/ISSUE_TEMPLATE/bug.yml
@@ -1,7 +1,7 @@
 name: "Bug Report"
 description: "Alert the team to a bug in the application"
 labels:
-  - bug
+  - bugfix
 body:
   - type: textarea
     id: description

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,12 @@
+# Description
+
+## Summary of Changes
+
+<!-- Provide a brief summary of the changes made in this pull request (use dot points) -->
+
+
+
+## Additional Comments
+
+<!-- Provide any additional comments or context for the changes made in this pull request (issues fixed, etc.) -->
+

--- a/app/core/process.py
+++ b/app/core/process.py
@@ -644,6 +644,8 @@ def start_background_process(config_filepath):
     # Set up the cameras
     cams = {}
     for index, c in enumerate(all_cameras):
+        if "Num" not in c:
+            c["Num"] = index
         if CameraCoreModel.main_camera is None:
             CameraCoreModel.main_camera = c["Num"]
         config_file = None


### PR DESCRIPTION
# Description

## Summary of Changes

<!-- Provide a brief summary of the changes made in this pull request (use dot points) -->

- Added check for when `"Num"` key is missing in the Picamera2 metadata
- Added a template for future pull requests
- Updating the `bug` issue template to assign the correct label upon creation (`bugfix`, was previously `bug` which doesn't actually exist). 

## Additional Comments

<!-- Provide any additional comments or context for the changes made in this pull request (issues fixed, etc.) -->

This PR resolves issue #1