### PR TITLE
Fixing Integration Workflow Rule Break

### DIFF
--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -14,7 +14,7 @@ on:
 
 jobs:
   format:
-    if: github.event_name == 'push'
+    if: github.event_name == 'push' && github.ref != 'refs/heads/main'
     name: Format
     runs-on: ubuntu-latest
     steps:


### PR DESCRIPTION
# Description

## Summary of Changes

<!-- Provide a brief summary of the changes made in this pull request (use dot points) -->

- The format job has been updated to not run when the commit is to main. 

## Additional Comments

<!-- Provide any additional comments or context for the changes made in this pull request (issues fixed, etc.) -->

The main branch is protected and requires a pull request to be made. The format job in the continuous integration workflow mimics the last user and attempts to push a new commit to whatever branch the last commit was on. When a pull request is merged into main, the format jobs does its thing and attempts to push changes to main but since it's mimicking a real user, it gets an error. 

Since the linting job is set to need the formatting job, the continuous integration as a whole will not operate on the main branch when a PR is merged. 