### PR TITLE
Fix sy macro execution feature

### DIFF
--- a/app/core/model.py
+++ b/app/core/model.py
@@ -64,6 +64,7 @@ class CameraCoreModel:
         "ag": ["autowbgain_r", "autowbgain_b"],
         "tl": "timelapse_start_stop",
         "tv": "tl_interval",
+        "sy": ["macro_script", "args"]
     }
 
     debug_execution_time = None

--- a/app/core/process.py
+++ b/app/core/process.py
@@ -539,6 +539,7 @@ def execute_command(index, cams, threads, cmd_tuple):
             parts = cmd_param.split(" ")
             script_name = parts[0]
             args = parts[1:] if len(parts) > 1 else []
+            model.print_to_logfile(f"Execute macro: '{script_name} {args}'")
             success = execute_macro_command(model, script_name, args)
             if success:
                 print(f"Successfully executed macro: {script_name} with args: {args}")


### PR DESCRIPTION
# Description

## Summary of Changes

During testing of the "sy" command, I found it did not work.

## Additional Comments

I traced the problem down to a missing entry in VALID_COMMANDS.
I also added a log entry for macro execution like the original software.
