### PR TITLE
Add support for php 8.2

### DIFF
--- a/etc/rpi-cam-web-interface/install.sh
+++ b/etc/rpi-cam-web-interface/install.sh
@@ -245,6 +245,8 @@ if [[ "$phpversion" == "7.4" ]]; then
    sed -i "s/\/var\/run\/php5-fpm\.sock;/\/run\/php\/php7.4-fpm\.sock;/g" $aconf
 elif [[ "$phpversion" == "7.3" ]]; then
    sed -i "s/\/var\/run\/php5-fpm\.sock;/\/run\/php\/php7.3-fpm\.sock;/g" $aconf
+elif [[ "$phpversion" == "8.2" ]]; then
+   sed -i "s/\/var\/run\/php5-fpm\.sock;/\/run\/php\/php8.2-fpm\.sock;/g" $aconf
 fi
 sudo sed -i -E "s/(listen.+?)80/\1$webport/g" $aconf
 # following line sets root url to direct subfolder. This is inconsistent with other usage.


### PR DESCRIPTION
# Description

## Summary of Changes

Added another branch on the explicit checks for PHP versions on RPICWI install script to support PHP 8.2.



## Additional Comments

There are explicitly checks for php versions 7.3 and 7.4 in the RPICWI repo included here. On my PI 2W on latest Bookworm, PHP 8.2 is included. I had to manually make this change for this project to work successfully. This contributes that change upstream!

